### PR TITLE
TerraformClient.java Fixed indentation

### DIFF
--- a/terraform-client/src/main/java/com/microsoft/terraform/TerraformClient.java
+++ b/terraform-client/src/main/java/com/microsoft/terraform/TerraformClient.java
@@ -136,11 +136,11 @@ public class TerraformClient implements AutoCloseable {
         return launcher;
     }
 
-	@Override
-	public void close() throws Exception {
+    @Override
+    public void close() throws Exception {
         this.executor.shutdownNow();
         if (!this.executor.awaitTermination(5, TimeUnit.SECONDS)) {
             throw new RuntimeException("executor did not terminate");
         }
-	}
+    }
 }


### PR DESCRIPTION
The projects use space characters for indentation, there were some tabs indentation TerraformClient.java which made the indentation appears wrong the Github code preview.