### PR TITLE
modify destroy non interactive command to -auto-approve

### DIFF
--- a/terraform-client/src/main/java/com/microsoft/terraform/TerraformClient.java
+++ b/terraform-client/src/main/java/com/microsoft/terraform/TerraformClient.java
@@ -14,7 +14,7 @@ public class TerraformClient implements AutoCloseable {
     private static final Map<String, String> NON_INTERACTIVE_COMMAND_MAP = new HashMap<>();
     static {
         NON_INTERACTIVE_COMMAND_MAP.put(APPLY_COMMAND, "-auto-approve");
-        NON_INTERACTIVE_COMMAND_MAP.put(DESTROY_COMMAND, "-force");
+        NON_INTERACTIVE_COMMAND_MAP.put(DESTROY_COMMAND, "-auto-approve");
     }
 
     private final ExecutorService executor = Executors.newWorkStealingPool();


### PR DESCRIPTION
since Terraform v0.12.0, the option '-force' was deprecated and since Terraform v0.15.0, the option '-force' was no longer accepted.
Terraform adopted '-auto-approve' for consistency with the terraform apply command, so since v0.12.0, we can all use '-auto-approve' to implement non-interactive commands.
see https://www.terraform.io/language/upgrade-guides/0-15